### PR TITLE
Feat: remove old deps, upgrade go version (#1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.13.x
-  - 1.14.x
+  - 1.19.x
   - tip
 
 before_install:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,5 @@
 module github.com/apparentlymart/go-versions
 
-go 1.14
+go 1.19
 
-require (
-	github.com/davecgh/go-spew v1.1.0
-	github.com/go-test/deep v1.0.1
-	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
-)
+require github.com/go-test/deep v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
-github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
-github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=

--- a/versions/constraints/canon_style_test.go
+++ b/versions/constraints/canon_style_test.go
@@ -3,7 +3,6 @@ package constraints
 import (
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/go-test/deep"
 )
 
@@ -668,8 +667,8 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			t.Logf("got: %s", spew.Sdump(got))
-			t.Logf("want: %s", spew.Sdump(test.Want))
+			t.Logf("got: %+v", got)
+			t.Logf("want: %+v", test.Want)
 
 			for _, problem := range deep.Equal(got, test.Want) {
 				t.Error(problem)

--- a/versions/constraints/raw_test.go
+++ b/versions/constraints/raw_test.go
@@ -1,9 +1,8 @@
 package constraints
 
 import (
+	"reflect"
 	"testing"
-
-	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestScanConstraints(t *testing.T) {
@@ -348,8 +347,8 @@ func TestScanConstraints(t *testing.T) {
 				t.Errorf("wrong remain\ngot:  %q\nwant: %q", remain, test.WantRemain)
 			}
 
-			if diff := pretty.Compare(test.Want, got); diff != "" {
-				t.Errorf("wrong result\n%s", diff)
+			if !reflect.DeepEqual(test.Want, got) {
+				t.Errorf("wrong result want %#v, got %#v", test.Want, got)
 			}
 		})
 	}

--- a/versions/parse_test.go
+++ b/versions/parse_test.go
@@ -3,8 +3,6 @@ package versions
 import (
 	"reflect"
 	"testing"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func TestMeetingConstraintsCanon(t *testing.T) {
@@ -259,7 +257,7 @@ func TestMeetingConstraintsCanon(t *testing.T) {
 				} else {
 					// Sometimes our GoString implementations hide differences that
 					// DeepEqual thinks are significant.
-					t.Errorf("wrong result\ngot:  %swant: %s", spew.Sdump(got), spew.Sdump(test.Want))
+					t.Errorf("wrong result\ngot:  %+vwant: %+v", got, test.Want)
 				}
 			}
 		})
@@ -399,7 +397,7 @@ func TestMeetingConstraintsRuby(t *testing.T) {
 				} else {
 					// Sometimes our GoString implementations hide differences that
 					// DeepEqual thinks are significant.
-					t.Errorf("wrong result\ngot:  %swant: %s", spew.Sdump(got), spew.Sdump(test.Want))
+					t.Errorf("wrong result\ngot:  %+vwant: %+v", got, test.Want)
 				}
 			}
 		})


### PR DESCRIPTION
Changelist:

* update go version to 1.19

* chore: removed dep to github.com/davecgh/go-spew because reached EOL

* chore: update github.com/go-test/deep dep

* chore: removed dep to github.com/kylelemons/godebug

* chore: upgrade go version in the travis script