### PR TITLE
versions: Requested versions eligible only if they were already present

### DIFF
--- a/versions/parse.go
+++ b/versions/parse.go
@@ -49,7 +49,7 @@ func MeetingConstraints(spec constraints.Spec) Set {
 	exact := MeetingConstraintsExact(spec)
 	reqd := exact.AllRequested().List()
 	set := Intersection(Released, exact)
-	reqd = reqd.Filter(Prerelease)
+	reqd = reqd.Filter(Prerelease).Filter(exact)
 	if len(reqd) != 0 {
 		set = Union(Selection(reqd...), set)
 	}

--- a/versions/parse_test.go
+++ b/versions/parse_test.go
@@ -382,6 +382,14 @@ func TestMeetingConstraintsRuby(t *testing.T) {
 				All.Subtract(Only(MustParseVersion(`1.0.0`))),
 			),
 		},
+		{
+			`1.0.0-beta1, != 1.0.0-beta1`, // degenerate empty set with prerelease versions
+			Intersection(
+				Released,
+				Only(MustParseVersion(`1.0.0-beta1`)),
+				All.Subtract(Only(MustParseVersion(`1.0.0-beta1`))),
+			),
+		},
 	}
 
 	for _, test := range tests {

--- a/versions/set_test.go
+++ b/versions/set_test.go
@@ -229,6 +229,11 @@ func TestSetHas(t *testing.T) {
 			true,
 		},
 		{
+			MustMakeSet(MeetingConstraintsStringRuby("!= 2.0.0-beta1, 2.0.0-beta1")),
+			MustParseVersion("2.0.0-beta1"),
+			false, // the constraint is contradictory, so includes nothing
+		},
+		{
 			MustMakeSet(MeetingConstraintsStringRuby(">= 1.0.0")),
 			MustParseVersion("1.0.1"),
 			true,


### PR DESCRIPTION
The `versions.MeetingConstraints` method tried to permit selection of any prereleases explicitly requested by an exact version constraint, but it didn't also check that those prereleases were included in the original set.

That worked okay for positive exact version constraints, like `1.0.0-beta.1`, but was incorrect for negative ones like `! 1.0.0-beta.1` which still get counted as "requested" in certain cases but that should not cause them to then be included in the overall result set.

Now we'll filter the list of requested versions first by membership of the "exact" set, so that the requested status of a version can only return versions that would've been eligible for inclusion in the original unfiltered set.

Fixes #4.
